### PR TITLE
Feature/pdct 1398 Add skeleton for GCF family mapping

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 ###############################################################################
-# GitHub Code-owner Configuration for bulk-import
+# GitHub Code-owner Configuration for GCF Data Mapper
 #
 # Each line is a file pattern followed by one or more owners. See this link:
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file
@@ -8,8 +8,8 @@
 
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence, members
-# of @climatepolicyradar/tech-devs will be requested for
+# of @climatepolicyradar/software will be requested for
 # review when someone opens a pull request. Teams should
 # be identified in the format @org/team-name. Teams must have
 # explicit write access to the repository.
-* @climatepolicyradar/tech-devs
+* @climatepolicyradar/software

--- a/gcf_data_mapper/cli.py
+++ b/gcf_data_mapper/cli.py
@@ -4,6 +4,7 @@ from typing import Any, Optional
 import click
 
 from gcf_data_mapper.parsers.collection import collection
+from gcf_data_mapper.parsers.family import family
 
 
 @click.command()
@@ -43,7 +44,7 @@ def wrangle_to_json(debug) -> dict[str, list[Optional[dict[str, Any]]]]:
     """
     return {
         "collections": collection(debug),
-        "families": [],
+        "families": family(debug),
         "documents": [],
         "events": [],
     }

--- a/gcf_data_mapper/parsers/family.py
+++ b/gcf_data_mapper/parsers/family.py
@@ -1,0 +1,17 @@
+from typing import Any, Optional
+
+import click
+
+
+def family(debug: bool) -> list[Optional[dict[str, Any]]]:
+    """Map the GCF family info to new structure.
+
+    :param bool debug: Whether debug mode is on.
+    :return list[Optional[dict[str, Any]]]: A list of GCF families in
+        the 'destination' format described in the GCF Data Mapper Google
+        Sheet.
+    """
+    if debug:
+        click.echo("📝 Wrangling GCF family data.")
+
+    return []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gcf-data-mapper"
-version = "0.1.2"
+version = "0.1.3"
 description = "A CLI tool to wrangle GCF data into format recognised by the bulk-import tool."
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 license = "Apache-2.0"

--- a/tests/unit_tests/parsers/family/test_family.py
+++ b/tests/unit_tests/parsers/family/test_family.py
@@ -1,0 +1,9 @@
+import pytest
+
+from gcf_data_mapper.parsers.family import family
+
+
+@pytest.mark.parametrize("debug", [True, False])
+def test_returns_empty(debug: bool):
+    family_data = family(debug)
+    assert family_data == []


### PR DESCRIPTION
# What's changed?

- Add skeleton for mapping family data
- Driveby fix codeowners to `software`

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
