### PR TITLE
Feature/pdct 1399 Add skeleton for GCF document mapping

### DIFF
--- a/gcf_data_mapper/cli.py
+++ b/gcf_data_mapper/cli.py
@@ -4,6 +4,7 @@ from typing import Any, Optional
 import click
 
 from gcf_data_mapper.parsers.collection import collection
+from gcf_data_mapper.parsers.document import document
 from gcf_data_mapper.parsers.family import family
 
 
@@ -45,7 +46,7 @@ def wrangle_to_json(debug) -> dict[str, list[Optional[dict[str, Any]]]]:
     return {
         "collections": collection(debug),
         "families": family(debug),
-        "documents": [],
+        "documents": document(debug),
         "events": [],
     }
 

--- a/gcf_data_mapper/parsers/document.py
+++ b/gcf_data_mapper/parsers/document.py
@@ -1,0 +1,17 @@
+from typing import Any, Optional
+
+import click
+
+
+def document(debug: bool) -> list[Optional[dict[str, Any]]]:
+    """Map the GCF document info to new structure.
+
+    :param bool debug: Whether debug mode is on.
+    :return list[Optional[dict[str, Any]]]: A list of GCF families in
+        the 'destination' format described in the GCF Data Mapper Google
+        Sheet.
+    """
+    if debug:
+        click.echo("📝 Wrangling GCF document data.")
+
+    return []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gcf-data-mapper"
-version = "0.1.3"
+version = "0.1.4"
 description = "A CLI tool to wrangle GCF data into format recognised by the bulk-import tool."
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 license = "Apache-2.0"

--- a/tests/unit_tests/parsers/document/test_document.py
+++ b/tests/unit_tests/parsers/document/test_document.py
@@ -1,0 +1,9 @@
+import pytest
+
+from gcf_data_mapper.parsers.document import document
+
+
+@pytest.mark.parametrize("debug", [True, False])
+def test_returns_empty(debug: bool):
+    document_data = document(debug)
+    assert document_data == []


### PR DESCRIPTION
# What's changed?

- Add skeleton for GCF document mapping

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
