### PR TITLE
Feature/pdct 1418 Make skeleton for GCF event data

### DIFF
--- a/gcf_data_mapper/cli.py
+++ b/gcf_data_mapper/cli.py
@@ -7,6 +7,7 @@ import pandas as pd
 
 from gcf_data_mapper.parsers.collection import collection
 from gcf_data_mapper.parsers.document import document
+from gcf_data_mapper.parsers.event import event
 from gcf_data_mapper.parsers.family import family
 from gcf_data_mapper.read import read
 
@@ -91,7 +92,7 @@ def wrangle_to_json(
         "collections": collection(debug),
         "families": family(project_info, debug),
         "documents": document(doc_info, debug),
-        "events": [],
+        "events": event(project_info, debug),
     }
 
 

--- a/gcf_data_mapper/parsers/event.py
+++ b/gcf_data_mapper/parsers/event.py
@@ -4,31 +4,13 @@ from typing import Any, Optional
 import click
 import pandas as pd
 
+from gcf_data_mapper.parsers.helpers import has_required_fields
+
 
 class RequiredColumns(Enum):
     APPROVED = "ApprovalDate"
     UNDER_IMPLEMENTATION = "StartDate"
     COMPLETED = "DateCompletion"
-
-
-def has_required_fields(
-    data: pd.DataFrame, required_fields: set[str], debug: bool = False
-) -> bool:
-    """Map the GCF event info to new structure.
-
-    :param pd.DataFrame data: The DataFrame to check.
-    :param set[str] required_fields: The required DataFrame columns.
-    :param bool debug: Whether debug mode is on.
-    :return bool: True if the DataFrame contains the required fields,
-        otherwise False.
-    """
-    diff = set(required_fields).difference(set(data.columns))
-    if diff == set():
-        return True
-
-    if debug:
-        click.echo(f"❌ Required fields '{diff}' not present in {set(data.columns)}")
-    return False
 
 
 def event(projects_data: pd.DataFrame, debug: bool) -> list[Optional[dict[str, Any]]]:

--- a/gcf_data_mapper/parsers/event.py
+++ b/gcf_data_mapper/parsers/event.py
@@ -4,7 +4,7 @@ from typing import Any, Optional
 import click
 import pandas as pd
 
-from gcf_data_mapper.parsers.helpers import has_required_fields
+from gcf_data_mapper.parsers.helpers import verify_required_fields_present
 
 
 class RequiredColumns(Enum):
@@ -27,7 +27,6 @@ def event(projects_data: pd.DataFrame, debug: bool) -> list[Optional[dict[str, A
         click.echo("📝 Wrangling GCF event data.")
 
     required_fields = set(str(e.value) for e in RequiredColumns)
-    if not has_required_fields(projects_data, required_fields):
-        return []
+    verify_required_fields_present(projects_data, required_fields)
 
     return []

--- a/gcf_data_mapper/parsers/event.py
+++ b/gcf_data_mapper/parsers/event.py
@@ -1,0 +1,20 @@
+from typing import Any, Optional
+
+import click
+import pandas as pd
+
+
+def event(projects_data: pd.DataFrame, debug: bool) -> list[Optional[dict[str, Any]]]:
+    """Map the GCF event info to new structure.
+
+    :param pd.DataFrame projects_data: The MCF and GCF project data,
+        joined on FP num.
+    :param bool debug: Whether debug mode is on.
+    :return list[Optional[dict[str, Any]]]: A list of GCF families in
+        the 'destination' format described in the GCF Data Mapper Google
+        Sheet.
+    """
+    if debug:
+        click.echo("📝 Wrangling GCF event data.")
+
+    return []

--- a/gcf_data_mapper/parsers/event.py
+++ b/gcf_data_mapper/parsers/event.py
@@ -1,7 +1,34 @@
+from enum import Enum
 from typing import Any, Optional
 
 import click
 import pandas as pd
+
+
+class RequiredColumns(Enum):
+    APPROVED = "ApprovalDate"
+    UNDER_IMPLEMENTATION = "StartDate"
+    COMPLETED = "DateCompletion"
+
+
+def has_required_fields(
+    data: pd.DataFrame, required_fields: set[str], debug: bool = False
+) -> bool:
+    """Map the GCF event info to new structure.
+
+    :param pd.DataFrame data: The DataFrame to check.
+    :param set[str] required_fields: The required DataFrame columns.
+    :param bool debug: Whether debug mode is on.
+    :return bool: True if the DataFrame contains the required fields,
+        otherwise False.
+    """
+    diff = set(required_fields).difference(set(data.columns))
+    if diff == set():
+        return True
+
+    if debug:
+        click.echo(f"❌ Required fields '{diff}' not present in {set(data.columns)}")
+    return False
 
 
 def event(projects_data: pd.DataFrame, debug: bool) -> list[Optional[dict[str, Any]]]:
@@ -16,5 +43,9 @@ def event(projects_data: pd.DataFrame, debug: bool) -> list[Optional[dict[str, A
     """
     if debug:
         click.echo("📝 Wrangling GCF event data.")
+
+    required_fields = set(str(e.value) for e in RequiredColumns)
+    if not has_required_fields(projects_data, required_fields):
+        return []
 
     return []

--- a/gcf_data_mapper/parsers/helpers.py
+++ b/gcf_data_mapper/parsers/helpers.py
@@ -9,6 +9,7 @@ def verify_required_fields_present(
     :param pd.DataFrame data: The DataFrame to check.
     :param set[str] required_fields: The required DataFrame columns.
     :param bool debug: Whether debug mode is on.
+    :raise AttributeError if any of the required fields are missing.
     :return bool: True if the DataFrame contains the required fields.
     """
     cols = set(data.columns)

--- a/gcf_data_mapper/parsers/helpers.py
+++ b/gcf_data_mapper/parsers/helpers.py
@@ -1,0 +1,22 @@
+import click
+import pandas as pd
+
+
+def has_required_fields(
+    data: pd.DataFrame, required_fields: set[str], debug: bool = False
+) -> bool:
+    """Map the GCF event info to new structure.
+
+    :param pd.DataFrame data: The DataFrame to check.
+    :param set[str] required_fields: The required DataFrame columns.
+    :param bool debug: Whether debug mode is on.
+    :return bool: True if the DataFrame contains the required fields,
+        otherwise False.
+    """
+    diff = set(required_fields).difference(set(data.columns))
+    if diff == set():
+        return True
+
+    if debug:
+        click.echo(f"❌ Required fields '{diff}' not present in {set(data.columns)}")
+    return False

--- a/gcf_data_mapper/parsers/helpers.py
+++ b/gcf_data_mapper/parsers/helpers.py
@@ -1,22 +1,21 @@
-import click
 import pandas as pd
 
 
-def has_required_fields(
-    data: pd.DataFrame, required_fields: set[str], debug: bool = False
+def verify_required_fields_present(
+    data: pd.DataFrame, required_fields: set[str]
 ) -> bool:
     """Map the GCF event info to new structure.
 
     :param pd.DataFrame data: The DataFrame to check.
     :param set[str] required_fields: The required DataFrame columns.
     :param bool debug: Whether debug mode is on.
-    :return bool: True if the DataFrame contains the required fields,
-        otherwise False.
+    :return bool: True if the DataFrame contains the required fields.
     """
-    diff = set(required_fields).difference(set(data.columns))
+    cols = set(data.columns)
+    diff = set(required_fields).difference(cols)
     if diff == set():
         return True
-
-    if debug:
-        click.echo(f"❌ Required fields '{diff}' not present in {set(data.columns)}")
-    return False
+    raise AttributeError(
+        f"Required fields '{str(diff)}' not present in df columns '"
+        f"{cols if cols != set() else r'{}'}'"
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gcf-data-mapper"
-version = "0.1.5"
+version = "0.1.6"
 description = "A CLI tool to wrangle GCF data into format recognised by the bulk-import tool."
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 license = "Apache-2.0"

--- a/tests/unit_tests/parsers/event/conftest.py
+++ b/tests/unit_tests/parsers/event/conftest.py
@@ -1,0 +1,31 @@
+import pandas as pd
+import pytest
+
+
+@pytest.fixture(
+    params=[
+        {
+            "col1": ["record1"],
+        },
+        {
+            "ApprovedRef": ["some_ref"],
+        },
+        {
+            "ApprovedRef": ["some_ref"],
+            "StartDate": ["some_start"],
+        },
+    ]
+)
+def required_cols_missing(request):
+    yield pd.DataFrame(request.param)
+
+
+@pytest.fixture()
+def valid_data():
+    yield pd.DataFrame(
+        {
+            "ApprovedRef": ["some_ref"],
+            "StartDate": ["some_start"],
+            "DateCompletion": ["some_end"],
+        }
+    )

--- a/tests/unit_tests/parsers/event/conftest.py
+++ b/tests/unit_tests/parsers/event/conftest.py
@@ -8,10 +8,10 @@ import pytest
             "col1": ["record1"],
         },
         {
-            "ApprovedRef": ["some_ref"],
+            "ApprovalDate": ["some_approval"],
         },
         {
-            "ApprovedRef": ["some_ref"],
+            "ApprovalDate": ["some_ref"],
             "StartDate": ["some_start"],
         },
     ]
@@ -24,7 +24,7 @@ def required_cols_missing(request):
 def valid_data():
     yield pd.DataFrame(
         {
-            "ApprovedRef": ["some_ref"],
+            "ApprovalDate": ["some_approval"],
             "StartDate": ["some_start"],
             "DateCompletion": ["some_end"],
         }

--- a/tests/unit_tests/parsers/event/test_event.py
+++ b/tests/unit_tests/parsers/event/test_event.py
@@ -1,9 +1,11 @@
+import pytest
+
 from gcf_data_mapper.parsers.event import event
 
 
 def test_returns_empty_when_cols_missing(required_cols_missing):
-    event_data = event(required_cols_missing, debug=False)
-    assert event_data == []
+    with pytest.raises(AttributeError):
+        event(required_cols_missing, debug=False)
 
 
 def test_success_with_valid_data(valid_data):

--- a/tests/unit_tests/parsers/event/test_event.py
+++ b/tests/unit_tests/parsers/event/test_event.py
@@ -1,9 +1,11 @@
-import pytest
-
 from gcf_data_mapper.parsers.event import event
 
 
-@pytest.mark.parametrize("debug", [True, False])
-def test_returns_empty(test_df, debug: bool):
-    event_data = event(test_df, debug)
+def test_returns_empty_when_cols_missing(required_cols_missing):
+    event_data = event(required_cols_missing, debug=False)
+    assert event_data == []
+
+
+def test_success_with_valid_data(valid_data):
+    event_data = event(valid_data, debug=False)
     assert event_data == []

--- a/tests/unit_tests/parsers/event/test_event.py
+++ b/tests/unit_tests/parsers/event/test_event.py
@@ -1,0 +1,9 @@
+import pytest
+
+from gcf_data_mapper.parsers.event import event
+
+
+@pytest.mark.parametrize("debug", [True, False])
+def test_returns_empty(test_df, debug: bool):
+    event_data = event(test_df, debug)
+    assert event_data == []

--- a/tests/unit_tests/parsers/helpers/test_has_required_fields.py
+++ b/tests/unit_tests/parsers/helpers/test_has_required_fields.py
@@ -21,7 +21,9 @@ from gcf_data_mapper.parsers.helpers import has_required_fields
         ),
     ],
 )
-def test_returns_false_when_missing_fields(test_df, expected_fields):
+def test_returns_false_when_missing_fields(
+    test_df: pd.DataFrame, expected_fields: set[str]
+):
     return_value = has_required_fields(test_df, expected_fields, debug=False)
     assert return_value is False
 
@@ -48,6 +50,8 @@ def test_returns_false_when_missing_fields(test_df, expected_fields):
         ),
     ],
 )
-def test_returns_true_when_no_missing_fields(test_df, expected_fields):
+def test_returns_true_when_no_missing_fields(
+    test_df: pd.DataFrame, expected_fields: set[str]
+):
     return_value = has_required_fields(test_df, expected_fields, debug=False)
     assert return_value is True

--- a/tests/unit_tests/parsers/helpers/test_has_required_fields.py
+++ b/tests/unit_tests/parsers/helpers/test_has_required_fields.py
@@ -1,0 +1,53 @@
+import pandas as pd
+import pytest
+
+from gcf_data_mapper.parsers.helpers import has_required_fields
+
+
+@pytest.mark.parametrize(
+    ("test_df", "expected_fields"),
+    [
+        (
+            pd.DataFrame(
+                {
+                    "fruits": ["apple", "banana", "cherry"],
+                }
+            ),
+            set(["fruits", "vegetables"]),
+        ),
+        (
+            pd.DataFrame(),
+            set(["cars"]),
+        ),
+    ],
+)
+def test_returns_false_when_missing_fields(test_df, expected_fields):
+    return_value = has_required_fields(test_df, expected_fields, debug=False)
+    assert return_value is False
+
+
+@pytest.mark.parametrize(
+    ("test_df", "expected_fields"),
+    [
+        (
+            pd.DataFrame(
+                {
+                    "fruits": ["date", "elderberry", "fig"],
+                    "vegetables": ["asparagus", "beetroot", "carrot"],
+                }
+            ),
+            set(["fruits", "vegetables"]),
+        ),
+        (
+            pd.DataFrame(
+                {
+                    "cars": ["Ford", "Renault", "Audi"],
+                }
+            ),
+            set(["cars"]),
+        ),
+    ],
+)
+def test_returns_true_when_no_missing_fields(test_df, expected_fields):
+    return_value = has_required_fields(test_df, expected_fields, debug=False)
+    assert return_value is True

--- a/tests/unit_tests/parsers/helpers/test_verify_required_fields_present.py
+++ b/tests/unit_tests/parsers/helpers/test_verify_required_fields_present.py
@@ -1,11 +1,11 @@
 import pandas as pd
 import pytest
 
-from gcf_data_mapper.parsers.helpers import has_required_fields
+from gcf_data_mapper.parsers.helpers import verify_required_fields_present
 
 
 @pytest.mark.parametrize(
-    ("test_df", "expected_fields"),
+    ("test_df", "expected_fields", "expected_error"),
     [
         (
             pd.DataFrame(
@@ -14,18 +14,21 @@ from gcf_data_mapper.parsers.helpers import has_required_fields
                 }
             ),
             set(["fruits", "vegetables"]),
+            "Required fields '{'vegetables'}' not present in df columns '{'fruits'}'",
         ),
         (
             pd.DataFrame(),
             set(["cars"]),
+            "Required fields '{'cars'}' not present in df columns '{}'",
         ),
     ],
 )
 def test_returns_false_when_missing_fields(
-    test_df: pd.DataFrame, expected_fields: set[str]
+    test_df: pd.DataFrame, expected_fields: set[str], expected_error: str
 ):
-    return_value = has_required_fields(test_df, expected_fields, debug=False)
-    assert return_value is False
+    with pytest.raises(AttributeError) as e:
+        verify_required_fields_present(test_df, expected_fields)
+    assert str(e.value) == expected_error
 
 
 @pytest.mark.parametrize(
@@ -53,5 +56,5 @@ def test_returns_false_when_missing_fields(
 def test_returns_true_when_no_missing_fields(
     test_df: pd.DataFrame, expected_fields: set[str]
 ):
-    return_value = has_required_fields(test_df, expected_fields, debug=False)
+    return_value = verify_required_fields_present(test_df, expected_fields)
     assert return_value is True


### PR DESCRIPTION
# What's changed?

- Make skeleton for GCF event data mapper
- Expand tests

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
