### PR TITLE
Feature/pdct 1398 map family to new json structure

### DIFF
--- a/gcf_data_mapper/enums/family.py
+++ b/gcf_data_mapper/enums/family.py
@@ -13,11 +13,14 @@ class FamilyColumnsNames(Enum):
     RESULT_AREAS = "ResultAreas"
     SECTOR = "Sector"
     THEME = "Theme"
+    TITLE = "ProjectName"
+    SUMMARY = "Summary"
 
 
 class FamilyNestedColumnNames(Enum):
     """The fields the GCF data mapper needs to parse nested family data/ metadata."""
 
+    COUNTRY_ISO3 = "ISO3"
     AREA = "Area"
     BUDGET = "BudgetUSDeq"
     NAME = "Name"

--- a/gcf_data_mapper/parsers/family.py
+++ b/gcf_data_mapper/parsers/family.py
@@ -113,6 +113,7 @@ def map_family_data(
     # and skip the row. Therefore we don't want to process the rest of the family data so we
     # return None in this conditional.
     if family_metadata is None:
+        click.echo("🛑 Skipping row as family metadata has missing information")
         return None
 
     approved_ref = row.at[FamilyColumnsNames.APPROVED_REF.value]
@@ -133,7 +134,7 @@ def map_family_data(
         "description": summary,
         "geographies": geographies,
         "import_id": import_id,
-        "metadata": map_family_metadata(row),
+        "metadata": family_metadata,
         "title": title,
     }
 

--- a/gcf_data_mapper/parsers/family.py
+++ b/gcf_data_mapper/parsers/family.py
@@ -131,6 +131,7 @@ def map_family_data(
     family_data = {
         # For now we are hard coding the category as MCF
         "category": "MCF",
+        "collections": [],
         "description": summary,
         "geographies": geographies,
         "import_id": import_id,

--- a/gcf_data_mapper/parsers/family.py
+++ b/gcf_data_mapper/parsers/family.py
@@ -98,8 +98,52 @@ def map_family_metadata(row: pd.Series) -> Optional[dict]:
     return metadata
 
 
+def map_family_data(
+    row: pd.Series,
+) -> Optional[dict]:
+    """Map the data of a family based on the provided row.
+
+    :param pd.Series row: The containing family and family metadata information.
+    :return Optional[dict]: A dictionary containing the mapped family data.
+    """
+
+    family_metadata = map_family_metadata(row)
+
+    # When processing the family metadata if there are any empty/falsy values we return None
+    # and skip the row. Therefore we don't want to process the rest of the family data so we
+    # return None in this conditional.
+    if family_metadata is None:
+        return None
+
+    approved_ref = row.at[FamilyColumnsNames.APPROVED_REF.value]
+    projects_id = row.at[FamilyColumnsNames.PROJECTS_ID.value]
+    summary = row.at[FamilyColumnsNames.SUMMARY.value]
+    title = row.at[FamilyColumnsNames.TITLE.value]
+
+    geographies = [
+        country[FamilyNestedColumnNames.COUNTRY_ISO3.value]
+        for country in row.at[FamilyColumnsNames.COUNTRIES.value]
+    ]
+
+    import_id = f"GCF.family.{approved_ref}.{projects_id}"
+
+    family_data = {
+        # For now we are hard coding the category as MCF
+        "category": "MCF",
+        "description": summary,
+        "geographies": geographies,
+        "import_id": import_id,
+        "metadata": map_family_metadata(row),
+        "title": title,
+    }
+
+    return family_data
+
+
 def process_row(
-    row: pd.Series, projects_id: str, required_columns: list[str]
+    row: pd.Series,
+    projects_id: str,
+    required_columns: list[str],
 ) -> Optional[dict]:
     """Map the family data based on the provided row.
 
@@ -121,13 +165,12 @@ def process_row(
         )
         return None
 
-    # TODO: Map family data
-    return {
-        "metadata": map_family_metadata(row),
-    }
+    return map_family_data(row)
 
 
-def family(projects_data: pd.DataFrame, debug: bool) -> list[Optional[dict[str, Any]]]:
+def family(
+    gcf_projects_data: pd.DataFrame, debug: bool
+) -> list[Optional[dict[str, Any]]]:
     """Map the GCF family info to new structure.
 
     :param pd.DataFrame projects_data: The MCF and GCF project data,
@@ -144,9 +187,11 @@ def family(projects_data: pd.DataFrame, debug: bool) -> list[Optional[dict[str, 
     mapped_families = []
 
     required_fields = set(str(e.value) for e in FamilyColumnsNames)
-    verify_required_fields_present(projects_data, required_fields)
 
-    for _, row in projects_data.iterrows():
+    verify_required_fields_present(gcf_projects_data, required_fields)
+    # Do a check that the projects data has the field you need
+
+    for _, row in gcf_projects_data.iterrows():
         projects_id = row.at[FamilyColumnsNames.PROJECTS_ID.value]
         mapped_families.append(process_row(row, projects_id, list(required_fields)))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gcf-data-mapper"
-version = "0.1.10"
+version = "0.1.11"
 description = "A CLI tool to wrangle GCF data into format recognised by the bulk-import tool."
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 license = "Apache-2.0"

--- a/tests/unit_tests/parsers/family/conftest.py
+++ b/tests/unit_tests/parsers/family/conftest.py
@@ -5,7 +5,7 @@ from gcf_data_mapper.enums.family import FamilyColumnsNames, FamilyNestedColumnN
 
 
 @pytest.fixture()
-def test_family_doc_df():
+def mock_family_doc_df():
     yield pd.DataFrame(
         [
             {
@@ -49,6 +49,133 @@ def test_family_doc_df():
                 ],
             }
         ]
+    )
+
+
+@pytest.fixture()
+def mock_family_row_ds():
+    yield pd.Series(
+        {
+            "ProjectsID": 1,
+            "ApprovedRef": "FP004",
+            "ProjectName": "Enhancing resilience of marine ecosystems",
+            "Theme": "Adaptation",
+            "Sector": "Private",
+            "ProjectURL": "https://www.climateaction.fund/project/FP004",
+            "Summary": "The Summary of the Project",
+            "Countries": [
+                {
+                    "CountryName": "Haiti",
+                    "ISO3": "HTI",
+                    "Region": "Latin America and the Caribbean",
+                },
+            ],
+            "Entities": [
+                {
+                    "Name": "Climate Action Innovations",
+                }
+            ],
+            "Funding": [
+                {
+                    "Source": "GCF",
+                    "Budget": 82000,
+                    "BudgetUSDeq": 82000,
+                },
+                {
+                    "ProjectBudgetID": 412,
+                    "Source": "Co-Financing",
+                    "Budget": 620000,
+                    "BudgetUSDeq": 620000,
+                },
+            ],
+            "ResultAreas": [
+                {
+                    "Area": "The Area for the Result Area",
+                    "Type": "The Type for the Result Area",
+                },
+            ],
+        }
+    )
+
+
+@pytest.fixture()
+def mock_family_row_no_result_areas():
+    yield pd.Series(
+        {
+            "ProjectsID": 2,
+            "ApprovedRef": "FP004",
+            "ProjectName": "Enhancing resilience of marine ecosystems",
+            "Theme": "Adaptation",
+            "Sector": "Private",
+            "ProjectURL": "https://www.climateaction.fund/project/FP004",
+            "Summary": "The Summary of the Project",
+            "Countries": [
+                {
+                    "CountryName": "Haiti",
+                    "ISO3": "HTI",
+                    "Region": "Latin America and the Caribbean",
+                },
+            ],
+            "Entities": [
+                {
+                    "Name": "Climate Action Innovations",
+                }
+            ],
+            "Funding": [
+                {
+                    "Source": "GCF",
+                    "Budget": 82000,
+                    "BudgetUSDeq": 82000,
+                },
+                {
+                    "ProjectBudgetID": 412,
+                    "Source": "Co-Financing",
+                    "Budget": 620000,
+                    "BudgetUSDeq": 620000,
+                },
+            ],
+            "ResultAreas": [
+                {"Area": "", "Type": ""},
+            ],
+        }
+    )
+
+
+@pytest.fixture()
+def mock_family_row_no_entities_no_regions():
+    yield pd.Series(
+        {
+            "ProjectsID": 3,
+            "ApprovedRef": "FP004",
+            "ProjectName": "Enhancing resilience of marine ecosystems",
+            "Theme": "Adaptation",
+            "Sector": "Private",
+            "ProjectURL": "https://www.climateaction.fund/project/FP004",
+            "Summary": "The Summary of the Project",
+            "Countries": [
+                {"Region": ""},
+            ],
+            "Entities": [{"Name": ""}],
+            "Funding": [
+                {
+                    "Source": "GCF",
+                    "Budget": 82000,
+                    "BudgetUSDeq": 82000,
+                },
+                {
+                    "ProjectBudgetID": 412,
+                    "Source": "Co-Financing",
+                    "Budget": 620000,
+                    "BudgetUSDeq": 620000,
+                },
+            ],
+            "ResultAreas": [
+                {
+                    "Area": "The Area for the Result Area",
+                    "Type": "The Type for the Result Area",
+                },
+            ],
+        }
     )
 
 

--- a/tests/unit_tests/parsers/family/conftest.py
+++ b/tests/unit_tests/parsers/family/conftest.py
@@ -15,6 +15,7 @@ def test_family_doc_df():
                 "Theme": "Adaptation",
                 "Sector": "Environment",
                 "ProjectURL": "https://www.climateaction.fund/project/FP003",
+                "Summary": "The Summary of the Project",
                 "Countries": [
                     {
                         "CountryName": "Bangladesh",

--- a/tests/unit_tests/parsers/family/test_family.py
+++ b/tests/unit_tests/parsers/family/test_family.py
@@ -8,6 +8,10 @@ from gcf_data_mapper.parsers.family import family, get_budgets, process_row
 def parsed_family_data():
     return [
         {
+            "category": "MCF",
+            "description": "The Summary of the Project",
+            "geographies": ["BGD"],
+            "import_id": "GCF.family.FP003.12660",
             "metadata": {
                 "approved_ref": ["FP003"],
                 "implementing_agencies": ["Green Innovations"],
@@ -20,7 +24,8 @@ def parsed_family_data():
                 "result_types": ["Adaptation"],
                 "sector": ["Environment"],
                 "theme": ["Adaptation"],
-            }
+            },
+            "title": "Enhancing resilience of coastal ecosystems and communities",
         }
     ]
 
@@ -44,11 +49,13 @@ def test_raises_error_on_validating_row_for_missing_columns():
                 "ProjectURL": "www.fake-url.com",
                 "ProjectsID": 100,
                 "ResultAreas": [{"Area": "Coastal"}],
+                "Summary": "Fake Summary",
+                "ProjectName": "Fake Project Name",
             }
         ]
     )
 
-    expected_error_message = "Required fields ['Countries', 'Sector', 'Theme'] not present in df columns ['ApprovedRef', 'Entities', 'Funding', 'ProjectURL', 'ProjectsID', 'ResultAreas']"
+    expected_error_message = "Required fields ['Countries', 'Sector', 'Theme'] not present in df columns ['ApprovedRef', 'Entities', 'Funding', 'ProjectName', 'ProjectURL', 'ProjectsID', 'ResultAreas', 'Summary']"
     with pytest.raises(AttributeError) as e:
         family(test_data_frame, debug=True)
     assert expected_error_message == str(e.value)
@@ -131,8 +138,10 @@ def test_returns_expected_value_when_parsing_budget_data(
                     "Funding": [{"Source": "GCF"}],
                     "ProjectURL": "www.fake-url.com",
                     "ProjectsID": 100,
+                    "ProjectName": "Fake Project Name",
                     "ResultAreas": [{"Area": "Coastal"}],
                     "Sector": "TestSector",
+                    "Summary": "Fake Summary",
                     "Theme": "TestTheme",
                 }
             ),

--- a/tests/unit_tests/parsers/family/test_map_family.py
+++ b/tests/unit_tests/parsers/family/test_map_family.py
@@ -151,3 +151,11 @@ def test_skips_processing_row_if_family_metadata_has_missing_data(
 ):
     family_data = map_family_data(mock_family_row_no_result_areas)
     assert family_data is None
+    captured = capsys.readouterr()
+    # We have two outputs, one from map_family_metadata pointing to the missing data and the second
+    # from map_family_data informing that the row is being skipped
+    map_family_data_output = captured.out.strip().split("\n")
+    assert (
+        "🛑 Skipping row as family metadata has missing information"
+        == map_family_data_output[1]
+    )

--- a/tests/unit_tests/parsers/family/test_map_family.py
+++ b/tests/unit_tests/parsers/family/test_map_family.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import pytest
 
-from gcf_data_mapper.parsers.family import family, get_budgets, process_row
+from gcf_data_mapper.parsers.family import family, map_family_data, process_row
 
 
 @pytest.fixture
@@ -31,12 +31,23 @@ def parsed_family_data():
 
 
 def test_returns_expected_family_data_structure(
-    test_family_doc_df: pd.DataFrame, parsed_family_data: list[dict]
+    mock_family_doc_df: pd.DataFrame, parsed_family_data: list[dict]
 ):
-    family_data = family(test_family_doc_df, debug=True)
+    family_data = family(mock_family_doc_df, debug=True)
     assert family_data != []
     assert len(family_data) == len(parsed_family_data)
     assert family_data == parsed_family_data
+
+
+def test_returns_expected_import_id_for_family_data(
+    mock_family_row_ds: pd.Series,
+):
+    approved_ref = mock_family_row_ds.ApprovedRef
+    projects_id = mock_family_row_ds.ProjectsID
+
+    family_data = map_family_data(mock_family_row_ds)
+    assert family_data is not None
+    assert family_data["import_id"] == f"GCF.family.{approved_ref}.{projects_id}"
 
 
 def test_raises_error_on_validating_row_for_missing_columns():
@@ -59,71 +70,6 @@ def test_raises_error_on_validating_row_for_missing_columns():
     with pytest.raises(AttributeError) as e:
         family(test_data_frame, debug=True)
     assert expected_error_message == str(e.value)
-
-
-@pytest.mark.parametrize(
-    ("funding_list, source, expected_value"),
-    [
-        (
-            [
-                {
-                    "Source": "GCF",
-                    "Budget": 1000,
-                    "BudgetUSDeq": 2000,
-                },
-                {
-                    "Source": "Co-Financing",
-                    "Budget": 1000,
-                    "BudgetUSDeq": 2000,
-                },
-            ],
-            "GCF",
-            [2000],
-        ),
-        (
-            [
-                {
-                    "Source": "GCF",
-                    "Budget": 1000,
-                    "BudgetUSDeq": 2000,
-                },
-                {
-                    "Source": "Co-Financing",
-                    "Budget": 1000,
-                    "BudgetUSDeq": 2000,
-                },
-                {
-                    "Source": "Co-Financing",
-                    "Budget": 2000,
-                    "BudgetUSDeq": 4000,
-                },
-            ],
-            "Co-Financing",
-            [2000, 4000],
-        ),
-        (
-            [
-                {
-                    "Source": "Co-Financing",
-                    "Budget": 1000,
-                    "BudgetUSDeq": 2000,
-                },
-                {
-                    "Source": "Co-Financing",
-                    "Budget": 2000,
-                    "BudgetUSDeq": 4000,
-                },
-            ],
-            "GCF",
-            [0],
-        ),
-    ],
-)
-def test_returns_expected_value_when_parsing_budget_data(
-    funding_list: list[dict], source: str, expected_value: list[int]
-):
-    budgets = get_budgets(funding_list, source)
-    assert budgets == expected_value
 
 
 @pytest.mark.parametrize(
@@ -194,7 +140,14 @@ def test_skips_processing_row_if_row_contains_empty_values(
     projects_id = test_ds.ProjectsID
 
     columns, _ = required_family_columns
-    expected_return = process_row(test_ds, projects_id, columns)
-    assert expected_return is None
+    family_data = process_row(test_ds, projects_id, columns)
+    assert expected_return == family_data
     captured = capsys.readouterr()
     assert error_message == captured.out.strip()
+
+
+def test_skips_processing_row_if_family_metadata_has_missing_data(
+    mock_family_row_no_result_areas, capsys
+):
+    family_data = map_family_data(mock_family_row_no_result_areas)
+    assert family_data is None

--- a/tests/unit_tests/parsers/family/test_map_family.py
+++ b/tests/unit_tests/parsers/family/test_map_family.py
@@ -9,6 +9,7 @@ def parsed_family_data():
     return [
         {
             "category": "MCF",
+            "collections": [],
             "description": "The Summary of the Project",
             "geographies": ["BGD"],
             "import_id": "GCF.family.FP003.12660",

--- a/tests/unit_tests/parsers/family/test_map_family_metadata.py
+++ b/tests/unit_tests/parsers/family/test_map_family_metadata.py
@@ -1,0 +1,119 @@
+import pandas as pd
+import pytest
+
+from gcf_data_mapper.parsers.family import get_budgets, map_family_metadata
+
+
+@pytest.fixture()
+def parsed_family_metadata():
+    return {
+        "approved_ref": ["FP004"],
+        "implementing_agencies": ["Climate Action Innovations"],
+        "project_id": [1],
+        "project_url": ["https://www.climateaction.fund/project/FP004"],
+        "project_value_co_financing": [620000],
+        "project_value_fund_spend": [82000],
+        "regions": ["Latin America and the Caribbean"],
+        "result_areas": ["The Area for the Result Area"],
+        "result_types": ["The Type for the Result Area"],
+        "sector": ["Private"],
+        "theme": ["Adaptation"],
+    }
+
+
+def test_returns_expected_metadata_structure(
+    mock_family_row_ds: pd.Series, parsed_family_metadata: dict
+):
+    family_metadata = map_family_metadata(mock_family_row_ds)
+    assert family_metadata is not None
+    assert family_metadata == parsed_family_metadata
+
+
+@pytest.mark.parametrize(
+    ("mock_family_row, expected_return, output_message"),
+    [
+        (
+            "mock_family_row_no_entities_no_regions",
+            None,
+            "🛑 The following lists contain empty values: Implementing Agencies, Regions. Projects ID 3",
+        ),
+        (
+            "mock_family_row_no_result_areas",
+            None,
+            "🛑 The following lists contain empty values: Result Areas, Result Types. Projects ID 2",
+        ),
+    ],
+)
+def test_returns_none_if_nested_values_in_family_metadata_row_contains_empty_values(
+    mock_family_row: pd.Series, expected_return, output_message: str, request, capsys
+):
+    family_metadata = map_family_metadata(request.getfixturevalue(mock_family_row))
+
+    assert family_metadata == expected_return
+    captured = capsys.readouterr()
+    assert output_message == captured.out.strip()
+
+
+@pytest.mark.parametrize(
+    ("funding_list, source, expected_value"),
+    [
+        (
+            [
+                {
+                    "Source": "GCF",
+                    "Budget": 1000,
+                    "BudgetUSDeq": 2000,
+                },
+                {
+                    "Source": "Co-Financing",
+                    "Budget": 1000,
+                    "BudgetUSDeq": 2000,
+                },
+            ],
+            "GCF",
+            [2000],
+        ),
+        (
+            [
+                {
+                    "Source": "GCF",
+                    "Budget": 1000,
+                    "BudgetUSDeq": 2000,
+                },
+                {
+                    "Source": "Co-Financing",
+                    "Budget": 1000,
+                    "BudgetUSDeq": 2000,
+                },
+                {
+                    "Source": "Co-Financing",
+                    "Budget": 2000,
+                    "BudgetUSDeq": 4000,
+                },
+            ],
+            "Co-Financing",
+            [2000, 4000],
+        ),
+        (
+            [
+                {
+                    "Source": "Co-Financing",
+                    "Budget": 1000,
+                    "BudgetUSDeq": 2000,
+                },
+                {
+                    "Source": "Co-Financing",
+                    "Budget": 2000,
+                    "BudgetUSDeq": 4000,
+                },
+            ],
+            "GCF",
+            [0],
+        ),
+    ],
+)
+def test_returns_expected_value_when_parsing_budget_data(
+    funding_list: list[dict], source: str, expected_value: list[int]
+):
+    budgets = get_budgets(funding_list, source)
+    assert budgets == expected_value


### PR DESCRIPTION
# What's changed?

Provide a general summary of your changes.

Updates the family data mapper to map the required fields for the family doc

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
