### PR TITLE
Feature/pdct 1453 update budget type checker to allow floats as well as ints

### DIFF
--- a/gcf_data_mapper/parsers/family.py
+++ b/gcf_data_mapper/parsers/family.py
@@ -166,16 +166,18 @@ def map_family_data(
     """
 
     family_metadata = map_family_metadata(row)
+    projects_id = row.at[FamilyColumnsNames.PROJECTS_ID.value]
 
     # When processing the family metadata if there are any empty/falsy values we return None
     # and skip the row. Therefore we don't want to process the rest of the family data so we
     # return None in this conditional.
     if family_metadata is None:
-        click.echo("🛑 Skipping row as family metadata has missing information")
+        click.echo(
+            f"🛑 Skipping row as family metadata has missing information, ProjectsID : {projects_id}"
+        )
         return None
 
     approved_ref = row.at[FamilyColumnsNames.APPROVED_REF.value]
-    projects_id = row.at[FamilyColumnsNames.PROJECTS_ID.value]
     summary = row.at[FamilyColumnsNames.SUMMARY.value]
     title = row.at[FamilyColumnsNames.TITLE.value]
 

--- a/gcf_data_mapper/parsers/family.py
+++ b/gcf_data_mapper/parsers/family.py
@@ -1,4 +1,4 @@
-from typing import Any, Iterable, Optional
+from typing import Any, Iterable, Optional, Union
 
 import click
 import pandas as pd
@@ -57,13 +57,15 @@ def calculate_status(row: pd.Series) -> Optional[str]:
     return None
 
 
-def get_budgets(funding_list: list[dict], source: str) -> Optional[list[int]]:
+def get_budgets(
+    funding_list: list[dict], source: str
+) -> Optional[list[Union[int, float]]]:
     """Get the budget amount from the row based on the funding source.
 
     :param list[dict] row: A list of all the funding information, represented in dictionaries
     :param str source: The funding source to retrieve the budget from.
 
-    :return Optional[list[int]]: A list of budget amounts corresponding to the source,
+    :return Optional[list[Union[int, float]]: A list of budget amounts corresponding to the source,
         or [0] if the source is not found.
     """
 
@@ -75,7 +77,7 @@ def get_budgets(funding_list: list[dict], source: str) -> Optional[list[int]]:
     ]
 
     # Check for any invalid values
-    if any(not isinstance(budget, (int)) for budget in budgets):
+    if any(not isinstance(budget, (int, float)) for budget in budgets):
         click.echo("🛑 Funding entries does not have valid int budget values")
         return None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gcf-data-mapper"
-version = "0.1.11"
+version = "0.1.12"
 description = "A CLI tool to wrangle GCF data into format recognised by the bulk-import tool."
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 license = "Apache-2.0"

--- a/tests/unit_tests/parsers/family/conftest.py
+++ b/tests/unit_tests/parsers/family/conftest.py
@@ -192,7 +192,7 @@ def mock_family_row_no_entities_no_regions():
 
 
 @pytest.fixture()
-def mock_family_row_with_non_int_budget_values():
+def mock_family_row_with_non_int_non_float_budget_values():
     yield pd.Series(
         {
             "ProjectsID": 3,
@@ -214,8 +214,8 @@ def mock_family_row_with_non_int_budget_values():
                 },
                 {
                     "Source": "Co-Financing",
-                    "Budget": 620000.20,
-                    "BudgetUSDeq": 620000.50,
+                    "Budget": "620000.20",
+                    "BudgetUSDeq": "620000.50",
                 },
             ],
             "ResultAreas": [

--- a/tests/unit_tests/parsers/family/test_map_family.py
+++ b/tests/unit_tests/parsers/family/test_map_family.py
@@ -152,8 +152,9 @@ def test_skips_processing_row_if_row_contains_empty_values(
 
 
 def test_skips_processing_row_if_family_metadata_has_missing_data(
-    mock_family_row_no_result_areas, capsys
+    mock_family_row_no_result_areas: pd.Series, capsys
 ):
+    projects_id = mock_family_row_no_result_areas.ProjectsID
     family_data = map_family_data(mock_family_row_no_result_areas)
     assert family_data is None
     captured = capsys.readouterr()
@@ -161,6 +162,6 @@ def test_skips_processing_row_if_family_metadata_has_missing_data(
     # from map_family_data informing that the row is being skipped
     map_family_data_output = captured.out.strip().split("\n")
     assert (
-        "🛑 Skipping row as family metadata has missing information"
+        f"🛑 Skipping row as family metadata has missing information, ProjectsID : {projects_id}"
         == map_family_data_output[1]
     )

--- a/tests/unit_tests/parsers/family/test_map_family_metadata.py
+++ b/tests/unit_tests/parsers/family/test_map_family_metadata.py
@@ -129,9 +129,9 @@ def test_returns_expected_value_when_parsing_budget_data(
 
 
 def test_map_family_metadata_returns_none_if_budget_does_not_contain_valid_int_types(
-    mock_family_row_with_non_int_budget_values: pd.Series,
+    mock_family_row_with_non_int_non_float_budget_values: pd.Series,
 ):
-    result = map_family_metadata(mock_family_row_with_non_int_budget_values)
+    result = map_family_metadata(mock_family_row_with_non_int_non_float_budget_values)
     assert result is None
 
 


### PR DESCRIPTION
# What's changed?

Provide a general summary of your changes.

Update the typing on the budget checker to allow for floats as well as ints

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
