### PR TITLE
feature/pdct-1554-map-gcf-source-url-to-document-pdf-not-url

### DIFF
--- a/gcf_data_mapper/enums/document.py
+++ b/gcf_data_mapper/enums/document.py
@@ -5,7 +5,7 @@ class RequiredDocumentColumns(Enum):
     TITLE = "Title"
     TYPE = "Type"
     ID = "ID (Unique ID from our CMS for the document)"
-    SOURCE_URL = "Document page permalink"
+    SOURCE_URL = "Main file (English)"
 
 
 class TranslatedDocumentColumns(Enum):

--- a/tests/unit_tests/parsers/document/conftest.py
+++ b/tests/unit_tests/parsers/document/conftest.py
@@ -10,6 +10,7 @@ import pytest
             "ID (Unique ID from our CMS for the document)": "doc123",
             "Type": "type123",
             "Title": "title123",
+            "Main file (English)": "link123.pdf",
             "Document page permalink": "link123",
             "Translated files": "http://example.com",
             "Translated titles": None,
@@ -20,6 +21,7 @@ import pytest
             "ID (Unique ID from our CMS for the document)": "doc123",
             "Type": "type123",
             "Title": "title123",
+            "Main file (English)": "link123.pdf",
             "Document page permalink": "link123",
             "Translated titles": None,
         },
@@ -38,6 +40,7 @@ def mock_valid_doc_row_with_one_translation():
             "ID (Unique ID from our CMS for the document)": "doc123",
             "Type": "type123",
             "Title": "title123",
+            "Main file (English)": "link123.pdf",
             "Document page permalink": "link123",
             "Translated files": "http://example.com",
             "Translated titles": "title123",
@@ -54,6 +57,7 @@ def mock_valid_doc_row_with_many_translations():
             "ID (Unique ID from our CMS for the document)": "doc123",
             "Type": "type123",
             "Title": "title123",
+            "Main file (English)": "link123.pdf",
             "Document page permalink": "link123,link456,link789",
             "Translated files": "http://example.com|http://example.org|http://example.co.uk",
             "Translated titles": "title123|title456|title789",
@@ -70,6 +74,7 @@ def mock_valid_doc_row_with_two_translations():
             "ID (Unique ID from our CMS for the document)": "doc123",
             "Type": "type123",
             "Title": "title123",
+            "Main file (English)": "link123.pdf",
             "Document page permalink": "link123,link456",
             "Translated files": "http://example.com|http://example.org",
             "Translated titles": "title123|title456",
@@ -86,6 +91,7 @@ def mock_valid_row():
             "ID (Unique ID from our CMS for the document)": "doc123",
             "Type": "type123",
             "Title": "title123",
+            "Main file (English)": "link123.pdf",
             "Document page permalink": "link123",
         }
     )
@@ -101,6 +107,7 @@ def mock_gcf_docs():
             "Title": ["title123", "title124"],
             "Translated titles": ["title123_fr", "title124_fr"],
             "Document page permalink": ["link123", "link124"],
+            "Main file (English)": ["link123.pdf", "link124.pdf"],
             "Translated files": ["file123_fr", "file124_fr"],
         }
     )

--- a/tests/unit_tests/parsers/document/test_map_document_data.py
+++ b/tests/unit_tests/parsers/document/test_map_document_data.py
@@ -14,5 +14,5 @@ def test_map_document_metadata_without_source_url(mock_valid_row):
     result = map_document_metadata(mock_valid_row, DocumentVariantNames.ORIGINAL.value)
     assert (
         "source_url" in result
-        and result["source_url"] == mock_valid_row["Document page permalink"]
+        and result["source_url"] == mock_valid_row["Main file (English)"]
     )


### PR DESCRIPTION
# What's changed?

Provide a general summary of your changes.

fix: document source url points to pdf

- we were incorrectly pointing to the permalink, not the url with that houses the pdf

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
