### PR TITLE
chore: set CODEOWNERS to @climatepolicyradar/enrichment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,15 +1,4 @@
-###############################################################################
-# GitHub Code-owner Configuration for GCF Data Mapper
-#
-# Each line is a file pattern followed by one or more owners. See this link:
-# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file
-# for more information on configuring GitHub code owners, including examples.
-###############################################################################
+# Ownership per [RFC] Ownership of code and services
+# https://www.notion.so/3a49109609a480c4ae38f1f5b2672675
 
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence, members
-# of @climatepolicyradar/application_engineers will be requested for
-# review when someone opens a pull request. Teams should
-# be identified in the format @org/team-name. Teams must have
-# explicit write access to the repository.
-* @climatepolicyradar/application_engineers
+* @climatepolicyradar/enrichment


### PR DESCRIPTION
## What

Points CODEOWNERS at `@climatepolicyradar/enrichment`, replacing `@climatepolicyradar/application_engineers`.

## Why

Implements Phase 1 of [\[RFC\] Ownership of code and services](https://www.notion.so/3a49109609a480c4ae38f1f5b2672675), which assigns this repository to Enrichment. Ownership here means stewardship and accountability — the owning team sets the quality bar and is accountable for the health of the repo. It is not gatekeeping: anyone may contribute to any CPR codebase, subject to following the owning team's documented process and PRing changes for review.

`@climatepolicyradar/application_engineers` is being sunset as a GitHub team once no codebase references it.

## Change

| | Before | After |
|---|---|---|
| Default owner (`*`) | `@climatepolicyradar/application_engineers` | `@climatepolicyradar/enrichment` |

Also in this PR:

- Replaced the boilerplate header, which named the owning team a second time in prose. The new header links the RFC and does not restate the rule
- Swept the repo for `@climatepolicyradar/application_engineers`. CODEOWNERS was the only file referencing it, so this repo stops blocking the team sunset once merged